### PR TITLE
Basic Syslog action with configurable address

### DIFF
--- a/actions/syslogaction.py
+++ b/actions/syslogaction.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+import logging.handlers
+
+from .basicaction import BasicAction
+
+
+class SyslogAction():
+    """Action to log a paste to the syslog"""
+    name = "SyslogAction"
+
+    def __init__(self, syslog_address="/dev/log"):
+        """
+        This sets up a syslogger, which defaults to /dev/log.
+        That means that it will work on most linux systems,
+        but will not work on for example OSX.
+
+        For OSX, the correct syslog address would be
+        /var/run/syslog
+        """
+        super().__init__()
+        self.logger = logging.getLogger('SyslogLogger')
+        self.logger.setLevel(logging.DEBUG)
+        handler = logging.handlers.SysLogHandler(address=syslog_address)
+        self.logger.addHandler(handler)
+
+    def perform(self, paste, analyzer_name=None):
+        self.logger.debug("New Paste matched: {0}".format(paste))

--- a/actions/syslogaction.py
+++ b/actions/syslogaction.py
@@ -4,7 +4,7 @@ import logging.handlers
 from .basicaction import BasicAction
 
 
-class SyslogAction():
+class SyslogAction(BasicAction):
     """Action to log a paste to the syslog"""
     name = "SyslogAction"
 
@@ -20,6 +20,7 @@ class SyslogAction():
         super().__init__()
         self.logger = logging.getLogger('SyslogLogger')
         self.logger.setLevel(logging.DEBUG)
+
         handler = logging.handlers.SysLogHandler(address=syslog_address)
         self.logger.addHandler(handler)
 


### PR DESCRIPTION
A simple action that logs to syslog. Supports both linux and osx through a constructor arg for the syslog address (which varies between systems). Will not affect other loggers elsewhere in the system.

This is related to #21 