### PR TITLE
Add Discord action (webhook or bot token)

### DIFF
--- a/pastepwn/actions/__init__.py
+++ b/pastepwn/actions/__init__.py
@@ -7,5 +7,6 @@ from .logaction import LogAction
 from .genericaction import GenericAction
 from .databaseaction import DatabaseAction
 from .savejsonaction import SaveJSONAction
+from .discordaction import DiscordAction
 
-__all__ = ('BasicAction', 'SaveFileAction', 'TelegramAction', 'LogAction', 'GenericAction', 'DatabaseAction', 'SaveJSONAction')
+__all__ = ('BasicAction', 'SaveFileAction', 'TelegramAction', 'LogAction', 'GenericAction', 'DatabaseAction', 'SaveJSONAction', 'DiscordAction')

--- a/pastepwn/actions/discordaction.py
+++ b/pastepwn/actions/discordaction.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import logging
-import json
 from string import Template
 
 from pastepwn.util import Request, DictWrapper
@@ -8,7 +7,7 @@ from .basicaction import BasicAction
 
 
 class DiscordAction(BasicAction):
-    """Action to send a Telegram message to a certain user or group"""
+    """Action to send a Discord message to a certain webhook or channel."""
     name = "DiscordAction"
 
     def __init__(self, webhook=None, token=None, channel_id=None, custom_payload=None, template=None):
@@ -28,7 +27,7 @@ class DiscordAction(BasicAction):
             self.template = None
 
     def perform(self, paste, analyzer_name=None):
-        """Send a message via a Telegram bot to a specified user, without checking for errors"""
+        """Send a message via Discord to a specified channel, without checking for errors"""
         r = Request()
         if self.template is None:
             text = "New paste matched by analyzer '{0}' - Link: {1}".format(analyzer_name, paste.full_url)

--- a/pastepwn/actions/discordaction.py
+++ b/pastepwn/actions/discordaction.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+import logging
+import re
+import json
+from string import Template
+
+from pastepwn.util import Request, DictWrapper
+from .basicaction import BasicAction
+
+
+class DiscordAction(BasicAction):
+    """Action to send a Telegram message to a certain user or group"""
+    name = "DiscordAction"
+
+    def __init__(self, webhook, custom_payload=None, template=None):
+        super().__init__()
+        self.logger = logging.getLogger(__name__)
+
+        self.webhook = webhook
+        self.custom_payload = custom_payload
+        if template is not None:
+            self.template = Template(template)
+        else:
+            self.template = None
+
+    def perform(self, paste, analyzer_name=None):
+        """Send a message via a Telegram bot to a specified user, without checking for errors"""
+        r = Request()
+        if self.template is None:
+            text = "New paste matched by analyzer '{0}' - Link: {1}".format(analyzer_name, paste.full_url)
+        else:
+            paste_dict = paste.to_dict()
+            paste_dict["analyzer_name"] = analyzer_name
+            text = self.template.safe_substitute(DictWrapper(paste_dict))
+        
+        pasteJson = json.dumps( {"content":paste})
+       
+        r.post(self.webhook, pasteJson)

--- a/pastepwn/actions/discordaction.py
+++ b/pastepwn/actions/discordaction.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
+import asyncio
+import json
 import logging
+import sys
+import websockets
 from string import Template
 
 from pastepwn.util import Request, DictWrapper
@@ -20,11 +24,67 @@ class DiscordAction(BasicAction):
                 raise ValueError('Invalid arguments: requires either webhook or token+channel_id arguments')
             self.token = token
             self.channel_id = channel_id
+            self.identified = False
         self.custom_payload = custom_payload
         if template is not None:
             self.template = Template(template)
         else:
             self.template = None
+
+    @asyncio.coroutine
+    def _identify(self, ws_url):
+        """Connect to the Discord Gateway to identify the bot."""
+        # Docs: https://discordapp.com/developers/docs/topics/gateway#connecting-to-the-gateway
+        # Open connection to the Discord Gateway
+        socket = yield from websockets.connect(ws_url + '/?v=6&encoding=json')
+        try:
+            # Receive Hello
+            hello_str = yield from socket.recv()
+            hello = json.loads(hello_str)
+            if hello.get('op') != 10:
+                self.logger.warning('[ws] Expected Hello payload but received %s', hello_str)
+            
+            # Send heartbeat and receive ACK
+            yield from socket.send(json.dumps({"op": 1, "d": {}}))
+            ack_str = yield from socket.recv()
+            ack = json.loads(ack_str)
+            if ack.get('op') != 11:
+                self.logger.warning('[ws] Expected Heartbeat ACK payload but received %s', ack_str)
+
+            # Identify
+            payload = {
+                "token": self.token,
+                "properties": {
+                    "$os": sys.platform,
+                    "$browser": "pastepwn",
+                    "$device": "pastepwn"
+                }
+            }
+            yield from socket.send(json.dumps({"op": 2, "d": payload}))
+
+            # Receive READY event
+            ready_str = yield from socket.recv()
+            ready = json.loads(ready_str)
+            if ready.get('t') != 'READY':
+                self.logger.warning('[ws] Expected READY event but received %s', ready_str)
+        finally:
+            # Close websocket connection
+            yield from socket.close()
+
+    def initialize_gateway(self):
+        """Initialize the bot token so Discord identifies it properly."""
+        if self.webhook is not None:
+            raise NotImplementedError('Gateway initialization is only necessary for bot accounts.')
+
+        # Call Get Gateway Bot to get the websocket URL
+        r = Request()
+        r.headers = {'Authorization': 'Bot {}'.format(self.token)}
+        res = json.loads(r.get('https://discordapp.com/api/gateway/bot'))
+        ws_url = res.get('url')
+
+        # Start websocket client
+        asyncio.get_event_loop().run_until_complete(self._identify(ws_url))
+        self.identified = True
 
     def perform(self, paste, analyzer_name=None):
         """Send a message via Discord to a specified channel, without checking for errors"""
@@ -44,4 +104,11 @@ class DiscordAction(BasicAction):
             url = 'https://discordapp.com/api/channels/{0}/messages'.format(self.channel_id)
             r.headers = {'Authorization': 'Bot {}'.format(self.token)}
 
-        r.post(url, {"content": text})
+        res = json.loads(r.post(url, {"content": text}))
+
+        if res.get('code') == 40001 and self.webhook is None and not self.identified:
+            # Unauthorized access, bot token hasn't been identified to Discord Gateway
+            self.logger.info('Accessing Discord Gateway to initialize token')
+            self.initialize_gateway()
+            # Retry action
+            self.perform(paste, analyzer_name=analyzer_name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pymongo
 mysql-connector-python
 requests
 python-twitter
+websockets>=7.0,<8


### PR DESCRIPTION
This includes commits from #85 which hasn't been merged yet.
Fixes #83 and expands on #85 by enabling users to have a `DiscordAction` with a custom bot token and channel ID, instead of just a webhook.

Both ways work just fine on my machine, but I haven't tried using fresh tokens, let me know if you encounter authentication issues.