### PR TITLE
Add AWS Secret Key Analyzer

### DIFF
--- a/pastepwn/analyzers/__init__.py
+++ b/pastepwn/analyzers/__init__.py
@@ -28,6 +28,7 @@ from .privatekeyanalyzer import PrivateKeyAnalyzer
 from .adobekeyanalyzer import AdobeKeyAnalyzer
 from .facebookaccesstokenanalyzer import FacebookAccessTokenAnalyzer
 from .base64analyzer import Base64Analyzer
+from .awssecretkeyanalyzer import AWSSecretKeyAnalyzer
 
 __all__ = (
     'AlwaysTrueAnalyzer',
@@ -57,5 +58,6 @@ __all__ = (
     'PrivateKeyAnalyzer',
     'EmailPasswordPairAnalyzer',
     'FacebookAccessTokenAnalyzer',
-    'Base64Analyzer'
+    'Base64Analyzer',
+    'AWSSecretKeyAnalyzer'
 )

--- a/pastepwn/analyzers/awssecretkeyanalyzer.py
+++ b/pastepwn/analyzers/awssecretkeyanalyzer.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from .regexanalyzer import RegexAnalyzer
+
+
+class AWSSecretKeyAnalyzer(RegexAnalyzer):
+    """
+    Analyzer to match AWS Secret Key via regex
+
+    Keys are 40 character alphanumeric with a few symbols /+=
+    """
+    name = "AWSSecretKeyAnalyzer"
+
+    def __init__(self, actions):
+        regex = r"\b[A-Za-z0-9/+=]{40}\b"
+        super().__init__(actions, regex)

--- a/pastepwn/analyzers/tests/awssecretkeyanalyzer_test.py
+++ b/pastepwn/analyzers/tests/awssecretkeyanalyzer_test.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+import unittest
+from unittest import mock
+
+from pastepwn.analyzers.awssecretkeyanalyzer import AWSSecretKeyAnalyzer
+
+
+class TestAWSSecretKeyAnalyzer(unittest.TestCase):
+    def setUp(self):
+        self.analyzer = AWSSecretKeyAnalyzer(None)
+        self.paste = mock.Mock()
+
+    def test_match_positive(self):
+        """Test if positives are recognized"""
+        # obtained by pastebin search
+        self.paste.body = "HrNMIhjZDnvkH5YGJpwjq0Flmj8H+dvURedLRjsO"
+        self.assertTrue(self.analyzer.match(self.paste))
+
+        # obtained by pastebin search
+        self.paste.body = "ZGBMmoyRxdhMObx0EuANS9FiS2kG5FwDVLH2XY7y"
+        self.assertTrue(self.analyzer.match(self.paste))
+
+        # obtained by pastebin search
+        self.paste.body = "kYKQ24NoNtmga55G7OVeY/kPAZ7xONl6FfmuXArc"
+        self.assertTrue(self.analyzer.match(self.paste))
+
+        # obtained by pastebin search
+        self.paste.body = "9cf95dacd226dcf43da376cdb6cbba7035218921"
+        self.assertTrue(self.analyzer.match(self.paste))
+
+        self.paste.body = "my super cool hash is 9cf95dacd226dcf43da376cdb6cbba7035218921 and here's some more text"
+        self.assertTrue(self.analyzer.match(self.paste))
+
+        self.paste.body = "AWS Secret Access Key [None]: HrNMIhjZDnvkH5YGJpwjq0Flmj8H+dvURedLRjsO"
+        self.assertTrue(self.analyzer.match(self.paste))
+
+        # Newline-separated valid hashes
+        self.paste.body = "ZGBMmoyRxdhMObx0EuANS9FiS2kG5FwDVLH2XY7y\nHrNMIhjZDnvkH5YGJpwjq0Flmj8H+dvURedLRjsO"
+        self.assertTrue(self.analyzer.match(self.paste))
+
+    def test_match_negative(self):
+        """Test if negatives are not recognized"""
+        self.paste.body = ""
+        self.assertFalse(self.analyzer.match(self.paste))
+
+        self.paste.body = None
+        self.assertFalse(self.analyzer.match(self.paste))
+
+        # Invalid character '-'
+        self.paste.body = "9cf95dacd226dcf43da376cdb6cbb-7035218921"
+        self.assertFalse(self.analyzer.match(self.paste))
+
+        # MD5 Hash
+        self.paste.body = "9e107d9d372bb6826bd81d3542a419d6"
+        self.assertFalse(self.analyzer.match(self.paste))
+
+        # Invalid length
+        self.paste.body = "ZGBMmoyRxdhMObx0EuANS9FiS2kG5FwDVLH2XY7y1"
+        self.assertFalse(self.analyzer.match(self.paste))
+        self.paste.body = "ZGBMmoyRxdhMObx0EuANS9FiS2kG5FwDVLH2XY7"
+        self.assertFalse(self.analyzer.match(self.paste))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
SHA hash and AWS secret keys are both 40 characters. All SHA (160 bit) hashes will report true from this regex, but AWS secret keys use more letters and also symbols. AWS Secret keys will rarely get detected as a SHA hash. I'm not sure of a better way to handle this unfortunately. This is for Issue #123.