### PR TITLE
TASK: Drop Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 sudo: require
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"


### PR DESCRIPTION
Support for Python 3.4 was dropped https://www.python.org/downloads/release/python-3410/